### PR TITLE
Add JVM Bash tool sample and tests

### DIFF
--- a/app/src/main/java/com/example/llmedgeexample/samples/CustomToolSamples.kt
+++ b/app/src/main/java/com/example/llmedgeexample/samples/CustomToolSamples.kt
@@ -1,0 +1,40 @@
+package com.example.llmedgeexample.samples
+
+import io.aatricks.llmedge.LLMEdge
+import io.aatricks.llmedge.text.TextModelOptions
+import io.aatricks.llmedge.tools.BashToolFactory
+import io.aatricks.llmedge.tools.BashToolOptions
+import io.aatricks.llmedge.tools.Tool
+import io.aatricks.llmedge.tools.ToolAgent
+import io.aatricks.llmedge.tools.ToolPolicies
+
+/**
+ * Example custom-tool wiring for JVM or desktop hosts that provide a bash-compatible shell.
+ *
+ * Android devices typically do not ship `bash`, so treat this as a host-side example rather than
+ * something the example app expects to execute successfully on-device.
+ */
+object CustomToolSamples {
+    fun buildJvmBashTools(): List<Tool> =
+        listOf(
+            BashToolFactory(
+                BashToolOptions(
+                    allowRawShell = true,
+                    defaultWorkingDirectory = ".",
+                ),
+            ).createBashTool(),
+        )
+
+    fun setupJvmBashAgent(edge: LLMEdge): ToolAgent =
+        edge.text.toolAgent(
+            tools = buildJvmBashTools(),
+            systemPrompt = "Use shell commands only when they materially help answer the user.",
+            options = TextModelOptions(useVulkan = false),
+            policy = ToolPolicies.ALLOW_ALL,
+        )
+
+    suspend fun runJvmBashExample(edge: LLMEdge): String =
+        setupJvmBashAgent(edge)
+            .reply("Run `pwd` with the bash tool and summarize the result.")
+            .text
+}

--- a/app/src/main/res/layout/activity_tool_calling_demo.xml
+++ b/app/src/main/res/layout/activity_tool_calling_demo.xml
@@ -24,6 +24,13 @@
             android:text="Downloads a GGUF instruct model, creates a ToolAgent with built-in device tools, runs read-only tools normally, and only allows action tools when the switch is enabled. Zero-argument tools like time and battery should be called with empty arguments."
             android:textColor="@android:color/darker_gray" />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Custom JVM-hosted tool example: see samples/CustomToolSamples.kt for BashToolFactory wiring. Android devices usually do not ship bash, so treat that sample as a host-side integration example."
+            android:textColor="@android:color/darker_gray" />
+
         <EditText
             android:id="@+id/inputToolModelId"
             android:layout_width="match_parent"

--- a/app/src/test/java/com/example/llmedgeexample/demo/image/ImageGenerationRequestPreparerTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/demo/image/ImageGenerationRequestPreparerTest.kt
@@ -1,6 +1,7 @@
 package com.example.llmedgeexample.demo.image
 
 import androidx.test.core.app.ApplicationProvider
+import io.aatricks.llmedge.LLMEdge
 import io.aatricks.llmedge.image.ImageGenerationRequest
 import io.aatricks.llmedge.image.diffusion.LoraApplyMode
 import java.io.File
@@ -20,13 +21,18 @@ class ImageGenerationRequestPreparerTest {
     @Test
     fun `toggle off returns original request`() = runTest {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val edge = LLMEdge.create(context, this)
         val baseRequest = ImageGenerationRequest(prompt = "city skyline", width = 128, height = 128)
         val preparer =
             ImageGenerationRequestPreparer(
                 loraDownloader = ImageLoraAssetDownloader { _, _ -> error("downloader should not be called") },
             )
 
-        val prepared = preparer.prepare(context, baseRequest, loraRequested = false)
+        val prepared = try {
+            preparer.prepare(edge, baseRequest, loraRequested = false)
+        } finally {
+            edge.close()
+        }
 
         assertFalse(prepared.loraApplied)
         assertEquals(baseRequest, prepared.request)
@@ -36,6 +42,7 @@ class ImageGenerationRequestPreparerTest {
     @Test
     fun `successful download appends lora tag and directory`() = runTest {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val edge = LLMEdge.create(context, this)
         val loraDirectory = File(context.filesDir, "loras").apply { mkdirs() }
         val loraFile = File(loraDirectory, "detail-tweaker.safetensors").apply { writeText("stub") }
         val statusMessages = mutableListOf<String>()
@@ -49,12 +56,16 @@ class ImageGenerationRequestPreparerTest {
             )
 
         val prepared =
-            preparer.prepare(
-                context = context,
-                baseRequest = ImageGenerationRequest(prompt = "city skyline", width = 128, height = 128),
-                loraRequested = true,
-                onStatus = statusMessages::add,
-            )
+            try {
+                preparer.prepare(
+                    edge = edge,
+                    baseRequest = ImageGenerationRequest(prompt = "city skyline", width = 128, height = 128),
+                    loraRequested = true,
+                    onStatus = statusMessages::add,
+                )
+            } finally {
+                edge.close()
+            }
 
         assertTrue(prepared.loraApplied)
         assertEquals("city skyline <lora:detail-tweaker:1.0>", prepared.request.prompt)
@@ -67,13 +78,18 @@ class ImageGenerationRequestPreparerTest {
     @Test
     fun `download failure reports warning and continues without lora`() = runTest {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val edge = LLMEdge.create(context, this)
         val baseRequest = ImageGenerationRequest(prompt = "city skyline", width = 128, height = 128)
         val preparer =
             ImageGenerationRequestPreparer(
                 loraDownloader = ImageLoraAssetDownloader { _, _ -> throw IllegalStateException("network down") },
             )
 
-        val prepared = preparer.prepare(context, baseRequest, loraRequested = true)
+        val prepared = try {
+            preparer.prepare(edge, baseRequest, loraRequested = true)
+        } finally {
+            edge.close()
+        }
 
         assertFalse(prepared.loraApplied)
         assertEquals(baseRequest, prepared.request)

--- a/app/src/test/java/com/example/llmedgeexample/samples/CustomToolSamplesTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/samples/CustomToolSamplesTest.kt
@@ -1,0 +1,20 @@
+package com.example.llmedgeexample.samples
+
+import io.aatricks.llmedge.tools.ToolKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomToolSamplesTest {
+    @Test
+    fun `bash tool sample exposes the custom action tool`() {
+        val tools = CustomToolSamples.buildJvmBashTools()
+
+        assertEquals(1, tools.size)
+        assertEquals("run_bash_command", tools.single().name)
+        assertEquals(ToolKind.ACTION, tools.single().kind)
+        assertTrue("argv" in tools.single().schema.parameters)
+        assertTrue("command" in tools.single().schema.parameters)
+        assertTrue("workingDirectory" in tools.single().schema.parameters)
+    }
+}


### PR DESCRIPTION
Update demo layout to reference the JVM-hosted sample and note bash caveats. Adjust image generation tests to create and close an LLMEdge instance and call preparer.prepare(edge, ...) instead of prepare(context, ...). Include a unit that verifies the bash tool's name, kind, and schema parameters.