### PR TITLE
Add MiniT2I image generation demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This example application provides production-ready demonstrations of llmedge's c
 
 **Image Generation** (`StableDiffusionActivity.kt`)
 - Text-to-image synthesis using Stable Diffusion
+- Selectable MiniT2I B/16 support with its FLAN-T5 Large text encoder
 - LoRA Support: Toggle switch to apply Detail Tweaker LoRA, automatically downloaded from Hugging Face
 - EasyCache: Auto-enabled acceleration for supported DiT models (Flux, SD3, Wan, Qwen Image, Z-Image)
 - Memory-aware configuration options

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
@@ -7,9 +7,6 @@ import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
-import io.aatricks.llmedge.image.diffusion.LoraApplyMode
-import io.aatricks.llmedge.image.Flux2Klein
-import io.aatricks.llmedge.image.ImageGenerationRequest
 import io.aatricks.llmedge.image.diffusion.GenerationMetrics
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -74,6 +71,12 @@ class ImageGenerationActivity : AppCompatActivity() {
                 Toast.makeText(this, "Detail Tweaker LoRA Disabled", Toast.LENGTH_SHORT).show()
             }
         }
+        views.flux2Toggle.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) views.miniT2iToggle.isChecked = false
+        }
+        views.miniT2iToggle.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) views.flux2Toggle.isChecked = false
+        }
 
         // Log initial memory state
         logDemoMemoryState(TAG, "Activity created", includeGpu = true)
@@ -109,35 +112,27 @@ class ImageGenerationActivity : AppCompatActivity() {
         views.generateButton.isEnabled = false
         val prompt = views.promptInput.text.toString().ifBlank { DEFAULT_PROMPT }
         val flux2Requested = views.flux2Toggle.isChecked
-        // FLUX.2 Klein is a split-model DiT pipeline; LoRA / Detail-Tweaker doesn't apply to it.
-        val loraRequested = views.loraToggle.isChecked && !flux2Requested
+        val miniT2iRequested = views.miniT2iToggle.isChecked
+        val loraRequested = views.loraToggle.isChecked && !flux2Requested && !miniT2iRequested
 
         val useFlashAttn = width >= 512 && height >= 512
-        val baseRequest =
-            if (flux2Requested) {
-                // Bonsai ternary Q2_K DiT (~1.3 GB) with sequential loading — peak RAM ≈ 2.6 GB,
-                // the low-memory FLUX.2 Klein path suited to ≤8 GB devices.
-                Flux2Klein.bonsaiImageRequest(
-                    prompt = prompt,
-                    width = width,
-                    height = height,
-                    seed = seed,
-                    flashAttention = useFlashAttn,
-                )
-            } else {
-                ImageGenerationRequest(
-                    prompt = prompt,
-                    width = width,
-                    height = height,
-                    steps = steps,
-                    cfgScale = cfg,
-                    seed = seed,
-                    flashAttention = useFlashAttn,
-                    forceSequentialLoad = false,
-                    loraModelDir = null,
-                    loraApplyMode = LoraApplyMode.AUTO,
-                )
+        val model =
+            when {
+                miniT2iRequested -> ImageGenerationModel.MINI_T2I
+                flux2Requested -> ImageGenerationModel.FLUX2_KLEIN
+                else -> ImageGenerationModel.DEFAULT
             }
+        val baseRequest =
+            ImageGenerationFormSupport.createRequest(
+                model = model,
+                prompt = prompt,
+                width = width,
+                height = height,
+                steps = steps,
+                cfgScale = cfg,
+                seed = seed,
+                flashAttention = useFlashAttn,
+            )
 
         requestPreparationJob =
             lifecycleScope.launch {

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationFormSupport.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationFormSupport.kt
@@ -1,8 +1,62 @@
 package com.example.llmedgeexample.demo.image
 
 import com.example.llmedgeexample.common.GenerationDemoSupport
+import io.aatricks.llmedge.image.Flux2Klein
+import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.image.MiniT2I
+import io.aatricks.llmedge.image.diffusion.LoraApplyMode
+
+internal enum class ImageGenerationModel {
+    DEFAULT,
+    FLUX2_KLEIN,
+    MINI_T2I,
+}
 
 internal object ImageGenerationFormSupport {
+    fun createRequest(
+        model: ImageGenerationModel,
+        prompt: String,
+        width: Int,
+        height: Int,
+        steps: Int,
+        cfgScale: Float,
+        seed: Long,
+        flashAttention: Boolean,
+    ): ImageGenerationRequest =
+        when (model) {
+            ImageGenerationModel.FLUX2_KLEIN ->
+                Flux2Klein.bonsaiImageRequest(
+                    prompt = prompt,
+                    width = width,
+                    height = height,
+                    seed = seed,
+                    flashAttention = flashAttention,
+                )
+            ImageGenerationModel.MINI_T2I ->
+                MiniT2I.imageRequest(
+                    prompt = prompt,
+                    width = width,
+                    height = height,
+                    steps = steps,
+                    cfgScale = cfgScale,
+                    seed = seed,
+                    flashAttention = flashAttention,
+                )
+            ImageGenerationModel.DEFAULT ->
+                ImageGenerationRequest(
+                    prompt = prompt,
+                    width = width,
+                    height = height,
+                    steps = steps,
+                    cfgScale = cfgScale,
+                    seed = seed,
+                    flashAttention = flashAttention,
+                    forceSequentialLoad = false,
+                    loraModelDir = null,
+                    loraApplyMode = LoraApplyMode.AUTO,
+                )
+        }
+
     fun parseDimensionField(
         field: android.widget.EditText,
         defaultValue: Int,
@@ -23,9 +77,9 @@ internal object ImageGenerationFormSupport {
         GenerationDemoSupport.parseIntField(
             field = field,
             defaultValue = defaultValue,
-            errorMessage = "Steps must be between 1 and 50",
+            errorMessage = "Steps must be between 1 and 100",
         ) { value ->
-            value in 1..50
+            value in 1..100
         }
 
     fun parseCfgField(

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationViews.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationViews.kt
@@ -24,6 +24,7 @@ internal data class ImageGenerationViews(
     val metricsLabel: TextView,
     val loraToggle: Switch,
     val flux2Toggle: Switch,
+    val miniT2iToggle: Switch,
 ) {
     companion object {
         fun bind(activity: Activity): ImageGenerationViews =
@@ -42,6 +43,7 @@ internal data class ImageGenerationViews(
                 metricsLabel = activity.findViewById(R.id.videoMetricsLabel),
                 loraToggle = activity.findViewById(R.id.loraToggle),
                 flux2Toggle = activity.findViewById(R.id.flux2Toggle),
+                miniT2iToggle = activity.findViewById(R.id.miniT2iToggle),
             )
     }
 }

--- a/app/src/main/res/layout/activity_image_generation.xml
+++ b/app/src/main/res/layout/activity_image_generation.xml
@@ -120,6 +120,13 @@
             android:layout_marginTop="12dp"
             android:text="FLUX.2 Klein 4B — Bonsai ternary Q2_K (~3.5GB DL, sequential load, ~6GB+ RAM)" />
 
+        <Switch
+            android:id="@+id/miniT2iToggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="MiniT2I B/16 — FLAN-T5 Large (512×512, 100 steps, CFG 6 recommended)" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/test/java/com/example/llmedgeexample/demo/image/ImageGenerationFormSupportTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/demo/image/ImageGenerationFormSupportTest.kt
@@ -1,0 +1,29 @@
+package com.example.llmedgeexample.demo.image
+
+import io.aatricks.llmedge.image.MiniT2I
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImageGenerationFormSupportTest {
+    @Test
+    fun `MiniT2I selection creates standalone diffusion request`() {
+        val request =
+            ImageGenerationFormSupport.createRequest(
+                model = ImageGenerationModel.MINI_T2I,
+                prompt = "a small robot",
+                width = 512,
+                height = 512,
+                steps = 100,
+                cfgScale = 6.0f,
+                seed = 42L,
+                flashAttention = true,
+            )
+
+        assertEquals(MiniT2I.diffusionModel, request.model)
+        assertEquals(MiniT2I.textEncoder, request.textEncoder)
+        assertTrue(request.diffusionModelOnly)
+        assertEquals(100, request.steps)
+        assertEquals(6.0f, request.cfgScale)
+    }
+}


### PR DESCRIPTION
Adds MiniT2I to the image generation demo with its model and FLAN-T5 inputs. The form uses MiniT2I defaults while keeping the existing image models unchanged.

Checked with the debug unit test suite.