### PR TITLE
Add Share Logs to the image generation demo

### DIFF
--- a/app/src/main/java/com/example/llmedgeexample/common/GenerationLogs.kt
+++ b/app/src/main/java/com/example/llmedgeexample/common/GenerationLogs.kt
@@ -1,0 +1,40 @@
+package com.example.llmedgeexample.common
+
+import android.app.Activity
+import android.content.Intent
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * Shared log-file sharing for the generation demos (video, image).
+ *
+ * Surfaces the app-wide [FileLogger] output as a shareable text file so users without logcat
+ * access can export generation logs — including failures such as model-resolution errors — for
+ * diagnosis.
+ */
+object GenerationLogs {
+    /** Friendly, user-visible location of the current log file (relative to `/Android/...`). */
+    fun currentLogPathLabel(): String? =
+        FileLogger.getCurrentLogFile()?.substringAfterLast("/Android/")
+
+    /** Build an `ACTION_SEND` intent for the current log file, or null if none exists yet. */
+    fun buildShareLogsIntent(activity: Activity): Intent? {
+        FileLogger.flush()
+        val logFile = FileLogger.getCurrentLogFile()?.let(::File)
+        if (logFile == null || !logFile.exists()) {
+            return null
+        }
+        val uri =
+            FileProvider.getUriForFile(
+                activity,
+                "${activity.packageName}.fileprovider",
+                logFile,
+            )
+        return Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra(Intent.EXTRA_SUBJECT, "LLMEdge Logs")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+}

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
@@ -2,6 +2,7 @@ package com.example.llmedgeexample.demo.image
 
 import com.example.llmedgeexample.R
 import com.example.llmedgeexample.common.*
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -78,8 +79,11 @@ class ImageGenerationActivity : AppCompatActivity() {
             if (isChecked) views.flux2Toggle.isChecked = false
         }
 
+        views.shareLogsButton.setOnClickListener { shareLogs() }
+        GenerationLogs.currentLogPathLabel()?.let { views.logPathLabel.text = it }
+
         // Log initial memory state
-        logDemoMemoryState(TAG, "Activity created", includeGpu = true)
+        logDemoMemoryState(TAG, "Activity created", includeGpu = true) { FileLogger.i(TAG, it) }
     }
 
     private fun startGeneration() {
@@ -153,8 +157,14 @@ class ImageGenerationActivity : AppCompatActivity() {
                         Toast.makeText(this@ImageGenerationActivity, it, Toast.LENGTH_LONG).show()
                     }
 
-                    logDemoMemoryState(TAG, "Before image generation", includeGpu = true)
+                    logDemoMemoryState(TAG, "Before image generation", includeGpu = true) { FileLogger.i(TAG, it) }
 
+                    val submitLog =
+                        "Submitting image request: width=${prepared.request.width}, height=${prepared.request.height}, steps=${prepared.request.steps}, " +
+                            "flash=${prepared.request.flashAttention}, easyCache=${prepared.request.easyCache.enabled}, " +
+                            "sequential=${prepared.request.forceSequentialLoad}, loraRequested=$loraRequested, " +
+                            "loraApplied=${prepared.loraApplied}, loraDir=${prepared.request.loraModelDir ?: "none"}"
+                    FileLogger.i(TAG, submitLog)
                     android.util.Log.i(
                         TAG,
                         "Submitting image request: width=${prepared.request.width}, height=${prepared.request.height}, steps=${prepared.request.steps}, " +
@@ -173,7 +183,7 @@ class ImageGenerationActivity : AppCompatActivity() {
                             ImageGenerationCallbacks(
                                 onProgress = ::updateProgressUI,
                                 onCompleted = { result ->
-                                    logDemoMemoryState(TAG, "After image generation", includeGpu = true)
+                                    logDemoMemoryState(TAG, "After image generation", includeGpu = true) { FileLogger.i(TAG, it) }
                                     views.previewImage.setImageBitmap(result.bitmap)
                                     result.metrics?.imageRequestMetrics?.let { imageMetrics ->
                                         android.util.Log.i(
@@ -211,6 +221,7 @@ class ImageGenerationActivity : AppCompatActivity() {
                         views.progressBar.visibility = View.GONE
                     }
                 } catch (t: Throwable) {
+                    FileLogger.e(TAG, "Failed to prepare image request", t)
                     android.util.Log.e(TAG, "Failed to prepare image request", t)
                     if (!isDestroyed) {
                         views.progressBar.visibility = View.GONE
@@ -233,6 +244,22 @@ class ImageGenerationActivity : AppCompatActivity() {
             return
         }
         controller.cancel(ImageGenerationCancellationReason.USER_CANCEL)
+    }
+
+    private fun shareLogs() {
+        val intent = GenerationLogs.buildShareLogsIntent(this)
+        if (intent == null) {
+            Toast.makeText(this, "No log file found", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        try {
+            startActivity(Intent.createChooser(intent, "Share Logs"))
+        } catch (e: Exception) {
+            FileLogger.e(TAG, "Failed to share logs", e)
+            val logFile = FileLogger.getCurrentLogFile()
+            Toast.makeText(this, "Log file: ${logFile ?: "unavailable"}", Toast.LENGTH_LONG).show()
+        }
     }
 
     private fun updateProgressUI(percent: Int, status: String) {

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationController.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationController.kt
@@ -1,6 +1,7 @@
 package com.example.llmedgeexample.demo.image
 
 import android.graphics.Bitmap
+import com.example.llmedgeexample.common.FileLogger
 import io.aatricks.llmedge.LLMEdge
 import io.aatricks.llmedge.image.ImageGenerationRequest
 import io.aatricks.llmedge.image.diffusion.GenerationMetrics
@@ -201,8 +202,10 @@ internal class ImageGenerationController(
     }
 
     private fun logInfo(message: String) {
+        // FileLogger.i writes to the shared log file AND logcat; guard so a mocked/absent
+        // android.util.Log (unit tests) still falls back to stdout.
         try {
-            android.util.Log.i(tag, message)
+            FileLogger.i(tag, message)
         } catch (_: Throwable) {
             println("I/$tag: $message")
         }
@@ -213,7 +216,7 @@ internal class ImageGenerationController(
         throwable: Throwable,
     ) {
         try {
-            android.util.Log.e(tag, message, throwable)
+            FileLogger.e(tag, message, throwable)
         } catch (_: Throwable) {
             System.err.println("E/$tag: $message")
             System.err.println(throwable.stackTraceToString())

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationViews.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationViews.kt
@@ -25,6 +25,8 @@ internal data class ImageGenerationViews(
     val loraToggle: Switch,
     val flux2Toggle: Switch,
     val miniT2iToggle: Switch,
+    val shareLogsButton: Button,
+    val logPathLabel: TextView,
 ) {
     companion object {
         fun bind(activity: Activity): ImageGenerationViews =
@@ -44,6 +46,8 @@ internal data class ImageGenerationViews(
                 loraToggle = activity.findViewById(R.id.loraToggle),
                 flux2Toggle = activity.findViewById(R.id.flux2Toggle),
                 miniT2iToggle = activity.findViewById(R.id.miniT2iToggle),
+                shareLogsButton = activity.findViewById(R.id.btnShareLogs),
+                logPathLabel = activity.findViewById(R.id.logPathLabel),
             )
     }
 }

--- a/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationActivity.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationActivity.kt
@@ -109,7 +109,7 @@ class VideoGenerationActivity : AppCompatActivity() {
         views.clearTaehvButton.setOnClickListener { clearTaehvFile() }
         views.shareLogsButton.setOnClickListener { shareLogs() }
 
-        VideoGenerationMediaSupport.currentLogPathLabel()?.let { path ->
+        GenerationLogs.currentLogPathLabel()?.let { path ->
             views.logPathLabel.text = path
         }
 
@@ -134,7 +134,7 @@ class VideoGenerationActivity : AppCompatActivity() {
     }
 
     private fun shareLogs() {
-        val intent = VideoGenerationMediaSupport.buildShareLogsIntent(this)
+        val intent = GenerationLogs.buildShareLogsIntent(this)
         if (intent == null) {
             Toast.makeText(this, "No log file found", Toast.LENGTH_SHORT).show()
             return

--- a/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationMediaSupport.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationMediaSupport.kt
@@ -1,14 +1,11 @@
 package com.example.llmedgeexample.demo.video
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Environment
-import androidx.core.content.FileProvider
-import com.example.llmedgeexample.common.FileLogger
 import com.example.llmedgeexample.common.copyOpenableToCache
 import io.aatricks.llmedge.vision.ImageUtils
 import java.io.File
@@ -25,9 +22,6 @@ internal data class CachedVideoAsset(
 )
 
 internal object VideoGenerationMediaSupport {
-    fun currentLogPathLabel(): String? =
-        FileLogger.getCurrentLogFile()?.substringAfterLast("/Android/")
-
     fun createImagePickerIntent(): Intent =
         Intent.createChooser(
             Intent(Intent.ACTION_GET_CONTENT).apply {
@@ -85,26 +79,6 @@ internal object VideoGenerationMediaSupport {
             file = file,
             selectionPath = file.absolutePath,
         )
-    }
-
-    fun buildShareLogsIntent(activity: Activity): Intent? {
-        FileLogger.flush()
-        val logFile = FileLogger.getCurrentLogFile()?.let(::File)
-        if (logFile == null || !logFile.exists()) {
-            return null
-        }
-        val uri =
-            FileProvider.getUriForFile(
-                activity,
-                "${activity.packageName}.fileprovider",
-                logFile,
-            )
-        return Intent(Intent.ACTION_SEND).apply {
-            type = "text/plain"
-            putExtra(Intent.EXTRA_STREAM, uri)
-            putExtra(Intent.EXTRA_SUBJECT, "LLMEdge Logs")
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        }
     }
 
     suspend fun saveFramesAsGif(

--- a/app/src/main/res/layout/activity_image_generation.xml
+++ b/app/src/main/res/layout/activity_image_generation.xml
@@ -188,5 +188,32 @@
             android:textColor="@android:color/black"
             android:visibility="gone" />
 
+        <!-- Log file access -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="16dp">
+
+            <Button
+                android:id="@+id/btnShareLogs"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Share Logs" />
+
+            <TextView
+                android:id="@+id/logPathLabel"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="8dp"
+                android:text="Logs saved to app storage"
+                android:textColor="@android:color/darker_gray"
+                android:textSize="12sp"
+                android:ellipsize="middle"
+                android:singleLine="true" />
+        </LinearLayout>
+
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Mirrors the T2V (video) demo's log feature in the image generation screen.

**What's added**
- A **Share Logs** button + log-path label at the bottom of the image screen (same UI as the video demo).
- Image-generation events — model submission, completion, cancellation, and failures — are written to the shared on-device `FileLogger`, so the exported log captures things like model-resolution errors (e.g. a "No file found …" during download).

**Refactor (no duplication)**
- Extracted the generic log-sharing helpers (`currentLogPathLabel`, `buildShareLogsIntent`) from the video demo into `common/GenerationLogs`, and migrated the video demo onto it. Both demos now share one implementation.

**Verified**
- App unit suite green (21 tests, 0 failures) — including `ImageGenerationControllerTest` with the new `FileLogger` routing.
- `:app:assembleDebug` builds (layout + resources + Kotlin compile OK).