### PR TITLE
Contain GPU driver crashes and fall back to CPU

### DIFF
--- a/app/src/main/java/com/example/llmedgeexample/common/EdgeSupport.kt
+++ b/app/src/main/java/com/example/llmedgeexample/common/EdgeSupport.kt
@@ -3,6 +3,7 @@ package com.example.llmedgeexample.common
 import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import io.aatricks.llmedge.ComputeBackendAvailability
+import io.aatricks.llmedge.DiffusionWorkerMode
 import io.aatricks.llmedge.ImageRuntimeConfig
 import io.aatricks.llmedge.LLMEdge
 import io.aatricks.llmedge.LLMEdgeConfig
@@ -28,7 +29,20 @@ fun bindEdge(
             config =
                 LLMEdgeConfig(
                     text = TextRuntimeConfig(useVulkan = !isCpuOnlyForced(context)),
-                    image = ImageRuntimeConfig(preferPerformanceMode = preferPerformanceMode && !isCpuOnlyForced(context)),
+                    // "Force CPU only" must also cover image/video: on devices whose Vulkan driver
+                    // loads but crashes/deadlocks at the first compute dispatch (e.g. some Mali /
+                    // PowerVR parts), useVulkan=false is the only escape hatch in IN_PROCESS mode.
+                    image =
+                        ImageRuntimeConfig(
+                            // Run image/video generation in the library's :llmedge_sd worker process
+                            // so a native GPU-driver crash/hang is contained and auto-retried on CPU
+                            // (hangRecoveryPolicy defaults to RETRY_CPU_THEN_FAIL; the broken backend
+                            // is blacklisted + persisted per device). Observed on the Dimensity 7025's
+                            // Mali driver, which loads Vulkan then crashes at the first compute dispatch.
+                            workerMode = DiffusionWorkerMode.ISOLATED_PROCESS,
+                            useVulkan = !isCpuOnlyForced(context),
+                            preferPerformanceMode = preferPerformanceMode && !isCpuOnlyForced(context),
+                        ),
                 ),
         ),
     )


### PR DESCRIPTION
Some GPU drivers (e.g. the Mali on a MediaTek Dimensity 7025) load Vulkan fine but crash at the first compute dispatch during generation, taking the whole app down.

- Run image/video generation in the isolated `:llmedge_sd` worker process, so a native driver crash is contained and the app survives. It is auto-retried on CPU, and the failing backend is blacklisted and persisted per device.
- The "Force CPU only" toggle now also disables Vulkan for image/video generation (it previously only affected text).