### PR TITLE
Expose SD3 FP8 T5XXL preset

### DIFF
--- a/app/src/main/res/layout/activity_image_generation.xml
+++ b/app/src/main/res/layout/activity_image_generation.xml
@@ -137,7 +137,7 @@
                 android:id="@+id/presetSd3Medium"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="SD3 Medium — split DiT + CLIP-L/G (~3.1GB DL, 28 steps, CFG 4.5)" />
+                android:text="SD3 Medium — split DiT + CLIP-L/G + T5XXL FP8 (full T5XXL FP8 conditioning, ~8.0GB total download)" />
 
             <RadioButton
                 android:id="@+id/presetMiniT2i"

--- a/app/src/test/java/com/example/llmedgeexample/demo/image/ImageModelPresetTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/demo/image/ImageModelPresetTest.kt
@@ -93,6 +93,7 @@ class ImageModelPresetTest {
         assertEquals(Sd3Medium.vae, request.vae)
         assertEquals(Sd3Medium.clipL, request.clipL)
         assertEquals(Sd3Medium.clipG, request.clipG)
+        assertEquals(Sd3Medium.t5xxl, request.t5xxl)
         assertNull(request.textEncoder)
         assertTrue(request.splitDiffusionModel)
         assertFalse(request.sequential)


### PR DESCRIPTION
Adds the full-T5XXL FP8 wording to the SD3 Medium example preset and verifies the preset carries the SDK T5XXL model specification.

Verified with ./gradlew :app:testDebugUnitTest --rerun-tasks and an arm64 APK installed on the connected SM-S901B.