### PR TITLE
Add Chroma Radiance and mobile Wan presets

### DIFF
--- a/app/src/main/java/com/example/llmedgeexample/common/DemoDiagnostics.kt
+++ b/app/src/main/java/com/example/llmedgeexample/common/DemoDiagnostics.kt
@@ -74,7 +74,7 @@ fun Context.buildDemoMemorySummary(cpuOnlyOverride: Boolean): String {
             appendLine("Vulkan mem: ${vulkanInfo.freeMemoryMB}MB / ${vulkanInfo.totalMemoryMB}MB")
         }
         if (isLowRamDevice()) {
-            appendLine("Note: Low RAM device - sequential loading enabled")
+            appendLine("Note: Low RAM device - video loading uses automatic memory planning")
         }
     }.trim()
 }

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.withContext
 
 /**
  * Activity for image generation supporting SD 1.5 (MeinaMix), FLUX.2 Klein Bonsai,
- * SD3 Medium, and MiniT2I.
+ * SD3 Medium, MiniT2I, and Chroma Radiance.
  *
  * Optimized for memory efficiency with:
  * - Proper model loading/unloading via LLMEdge
@@ -98,6 +98,7 @@ class ImageGenerationActivity : AppCompatActivity() {
             R.id.presetSd3Medium -> ImageModelPreset.SD3_MEDIUM
             R.id.presetMiniT2i -> ImageModelPreset.MINI_T2I
             R.id.presetMiniT2iLarge -> ImageModelPreset.MINI_T2I_LARGE
+            R.id.presetChromaRadiance -> ImageModelPreset.CHROMA_RADIANCE
             else -> ImageModelPreset.SD15
         }
     }

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageModelPreset.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageModelPreset.kt
@@ -4,6 +4,7 @@ import io.aatricks.llmedge.image.Flux2Klein
 import io.aatricks.llmedge.image.ImageGenerationRequest
 import io.aatricks.llmedge.image.MiniT2I
 import io.aatricks.llmedge.image.Sd3Medium
+import io.aatricks.llmedge.image.ChromaRadiance
 import io.aatricks.llmedge.image.diffusion.LoraApplyMode
 
 internal enum class ImageModelPreset(
@@ -17,7 +18,8 @@ internal enum class ImageModelPreset(
     FLUX2_KLEIN_BONSAI(512, 512, 4, 1.0f, false),
     SD3_MEDIUM(512, 512, 28, 4.5f, false),
     MINI_T2I(512, 512, 100, 6.0f, false),
-    MINI_T2I_LARGE(512, 512, 100, 6.0f, false);
+    MINI_T2I_LARGE(512, 512, 100, 6.0f, false),
+    CHROMA_RADIANCE(512, 512, 20, 4.0f, false);
 
     fun buildRequest(
         prompt: String,
@@ -69,6 +71,15 @@ internal enum class ImageModelPreset(
                 flashAttention = flashAttention,
             )
             MINI_T2I_LARGE -> MiniT2I.largeImageRequest(
+                prompt = prompt,
+                width = width,
+                height = height,
+                steps = steps,
+                cfgScale = cfg,
+                seed = seed,
+                flashAttention = flashAttention,
+            )
+            CHROMA_RADIANCE -> ChromaRadiance.imageRequest(
                 prompt = prompt,
                 width = width,
                 height = height,

--- a/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationController.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationController.kt
@@ -67,10 +67,8 @@ class VideoGenerationController(
     fun start(config: VideoGenerationConfig, callbacks: VideoGenerationCallbacks) {
         check(!isGenerating()) { "Video generation already running" }
 
-        val isLowMemoryDevice = context.isLowRamDevice()
         val availableMemoryMb = context.availableMemoryMb()
         val actualFrames = (config.frames - 1) / 4 * 4 + 1
-        val useSequentialLoad = isLowMemoryDevice || availableMemoryMb < 2500L
 
         FileLogger.separator("Video Generation Starting")
         FileLogger.i(tag, "Parameters:")
@@ -85,7 +83,7 @@ class VideoGenerationController(
         FileLogger.i(tag, "  I2V: ${config.initImage != null}, Strength: ${config.initImageStrength}")
         FileLogger.i(
             tag,
-            "  Memory: isLowMem=$isLowMemoryDevice, available=${availableMemoryMb}MB",
+            "  Memory: available=${availableMemoryMb}MB, loading=automatic",
         )
 
         generationJob =
@@ -107,7 +105,7 @@ class VideoGenerationController(
                     FileLogger.i(tag, "Init image ready: ${resizedInitImage != null}")
                     FileLogger.i(
                         tag,
-                        "Generation mode: ${if (useSequentialLoad) "sequential" else "direct"} (isLowMem=$isLowMemoryDevice, available=${availableMemoryMb}MB)",
+                        "Generation mode: automatic (available=${availableMemoryMb}MB)",
                     )
 
                     withContext(Dispatchers.Main) {
@@ -128,7 +126,7 @@ class VideoGenerationController(
                             vae = config.vae,
                             textEncoder = config.textEncoder,
                             flashAttention = true,
-                            forceSequentialLoad = useSequentialLoad,
+                            forceSequentialLoad = false,
                             sampleMethod = config.sampleMethod,
                             scheduler = config.scheduler,
                             loraModelDir = config.loraDirectory ?: config.defaultLoraDirectory,

--- a/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationFormSupport.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationFormSupport.kt
@@ -20,13 +20,63 @@ internal data class VideoModelPreset(
 )
 
 internal object VideoGenerationFormSupport {
+    private const val WAN_21_GGUF_REPO = "samuelchristlie/Wan2.1-T2V-1.3B-GGUF"
+    private const val WAN_21_REPO = "Comfy-Org/Wan_2.1_ComfyUI_repackaged"
+    private const val WAN_T5_REPO = "city96/umt5-xxl-encoder-gguf"
     private const val WAN_22_REPO = "QuantStack/Wan2.2-TI2V-5B-GGUF"
     private val recommendedSamplers = SampleMethod.WAN_RECOMMENDED
     private val orderedSamplers =
         recommendedSamplers + SampleMethod.values().filter { it !in recommendedSamplers }
     val modelPresets =
         listOf(
-            VideoModelPreset(displayName = "Wan 2.1 T2V 1.3B (default)"),
+            VideoModelPreset(
+                displayName = "Wan 2.1 T2V 1.3B Q3_K_S (mobile default)",
+                model =
+                    ModelSpec.huggingFace(
+                        repoId = WAN_21_GGUF_REPO,
+                        filename = "Wan2.1-T2V-1.3B-Q3_K_S.gguf",
+                        hints =
+                            ModelHints(
+                                artifactKind = ModelArtifactKind.DIFFUSION_MODEL,
+                                capabilities = setOf(ModelCapability.IMAGE, ModelCapability.VIDEO),
+                            ),
+                    ),
+                vae =
+                    ModelSpec.huggingFace(
+                        repoId = WAN_21_REPO,
+                        filename = "wan_2.1_vae.safetensors",
+                        hints =
+                            ModelHints(
+                                artifactKind = ModelArtifactKind.VAE,
+                                capabilities = setOf(ModelCapability.VIDEO),
+                            ),
+                    ),
+                textEncoder = wanTextEncoder(),
+            ),
+            VideoModelPreset(
+                displayName = "Wan 2.1 T2V 1.3B fp16 (high memory)",
+                model =
+                    ModelSpec.huggingFace(
+                        repoId = WAN_21_REPO,
+                        filename = "wan2.1_t2v_1.3B_fp16.safetensors",
+                        hints =
+                            ModelHints(
+                                artifactKind = ModelArtifactKind.DIFFUSION_MODEL,
+                                capabilities = setOf(ModelCapability.IMAGE, ModelCapability.VIDEO),
+                            ),
+                    ),
+                vae =
+                    ModelSpec.huggingFace(
+                        repoId = WAN_21_REPO,
+                        filename = "wan_2.1_vae.safetensors",
+                        hints =
+                            ModelHints(
+                                artifactKind = ModelArtifactKind.VAE,
+                                capabilities = setOf(ModelCapability.VIDEO),
+                            ),
+                    ),
+                textEncoder = wanTextEncoder(),
+            ),
             VideoModelPreset(
                 displayName = "Wan 2.2 TI2V 5B Q6_K",
                 model =
@@ -50,6 +100,17 @@ internal object VideoGenerationFormSupport {
                             ),
                     ),
             ),
+        )
+
+    private fun wanTextEncoder(): ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = WAN_T5_REPO,
+            filename = "umt5-xxl-encoder-Q3_K_S.gguf",
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.TEXT_ENCODER,
+                    capabilities = setOf(ModelCapability.TEXT, ModelCapability.VIDEO),
+                ),
         )
 
     fun bindAdapters(

--- a/app/src/main/res/layout/activity_image_generation.xml
+++ b/app/src/main/res/layout/activity_image_generation.xml
@@ -150,6 +150,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="MiniT2I L/16 — FLAN-T5 Large (512×512, 100 steps, CFG 6)" />
+
+            <RadioButton
+                android:id="@+id/presetChromaRadiance"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Chroma Radiance — split DiT + T5XXL (512×512, 20 steps, CFG 4)" />
         </RadioGroup>
 
         <LinearLayout

--- a/app/src/test/java/com/example/llmedgeexample/demo/image/ImageModelPresetTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/demo/image/ImageModelPresetTest.kt
@@ -33,6 +33,10 @@ class ImageModelPresetTest {
         assertEquals(6.0f, ImageModelPreset.MINI_T2I_LARGE.defaultCfg)
         assertFalse(ImageModelPreset.MINI_T2I_LARGE.supportsLora)
 
+        assertEquals(20, ImageModelPreset.CHROMA_RADIANCE.defaultSteps)
+        assertEquals(4.0f, ImageModelPreset.CHROMA_RADIANCE.defaultCfg)
+        assertFalse(ImageModelPreset.CHROMA_RADIANCE.supportsLora)
+
         ImageModelPreset.values().forEach { preset ->
             assertEquals(512, preset.defaultWidth)
             assertEquals(512, preset.defaultHeight)
@@ -143,5 +147,29 @@ class ImageModelPresetTest {
         assertEquals(100, request.steps)
         assertEquals(6.0f, request.cfgScale)
         assertNull(request.sequential)
+    }
+
+    @Test
+    fun testBuildRequestChromaRadiance() {
+        val request = ImageModelPreset.CHROMA_RADIANCE.buildRequest(
+            prompt = "a small robot",
+            width = 512,
+            height = 512,
+            steps = 20,
+            cfg = 4.0f,
+            seed = 42L,
+            flashAttention = true,
+        )
+
+        assertEquals(io.aatricks.llmedge.image.ChromaRadiance.diffusionModel, request.model)
+        assertEquals(io.aatricks.llmedge.image.ChromaRadiance.t5xxl, request.t5xxl)
+        assertNull(request.vae)
+        assertNull(request.clipL)
+        assertNull(request.clipG)
+        assertNull(request.textEncoder)
+        assertTrue(request.splitDiffusionModel)
+        assertEquals(true, request.sequential)
+        assertEquals(20, request.steps)
+        assertEquals(4.0f, request.cfgScale)
     }
 }

--- a/app/src/test/java/com/example/llmedgeexample/demo/video/VideoGenerationFormSupportTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/demo/video/VideoGenerationFormSupportTest.kt
@@ -33,14 +33,26 @@ class VideoGenerationFormSupportTest {
     }
 
     @Test
-    fun `model presets default to Wan 2_1 and include Wan 2_2 Q6`() {
+    fun `model presets default to mobile Wan 2_1 and retain fp16 and Wan 2_2`() {
         val presets = VideoGenerationFormSupport.modelPresets
 
-        assertEquals("Wan 2.1 T2V 1.3B (default)", presets.first().displayName)
-        assertNull(presets.first().model)
-        assertNull(presets.first().vae)
+        assertEquals("Wan 2.1 T2V 1.3B Q3_K_S (mobile default)", presets.first().displayName)
+        val mobileModel = presets.first().model as? ModelSpec.HuggingFace
+        val mobileVae = presets.first().vae as? ModelSpec.HuggingFace
+        val mobileEncoder = presets.first().textEncoder as? ModelSpec.HuggingFace
+        assertEquals("samuelchristlie/Wan2.1-T2V-1.3B-GGUF", mobileModel?.repoId)
+        assertEquals("Wan2.1-T2V-1.3B-Q3_K_S.gguf", mobileModel?.filename)
+        assertEquals("Comfy-Org/Wan_2.1_ComfyUI_repackaged", mobileVae?.repoId)
+        assertEquals("wan_2.1_vae.safetensors", mobileVae?.filename)
+        assertEquals("city96/umt5-xxl-encoder-gguf", mobileEncoder?.repoId)
+        assertEquals("umt5-xxl-encoder-Q3_K_S.gguf", mobileEncoder?.filename)
 
-        val wan22 = presets[1]
+        val fp16 = presets[1]
+        assertEquals("Wan 2.1 T2V 1.3B fp16 (high memory)", fp16.displayName)
+        assertEquals("wan2.1_t2v_1.3B_fp16.safetensors", (fp16.model as? ModelSpec.HuggingFace)?.filename)
+        assertEquals("umt5-xxl-encoder-Q3_K_S.gguf", (fp16.textEncoder as? ModelSpec.HuggingFace)?.filename)
+
+        val wan22 = presets[2]
         assertEquals("Wan 2.2 TI2V 5B Q6_K", wan22.displayName)
         val model = wan22.model as? ModelSpec.HuggingFace
         val vae = wan22.vae as? ModelSpec.HuggingFace


### PR DESCRIPTION
## What changed

- Added Chroma Radiance to the image model selector.
- Made Wan 2.1 Q3_K_S the mobile default while keeping the fp16 preset available.
- Switched video generation to the SDK automatic memory planner.
- Updated diagnostics and preset tests.

## Why

The examples app needed a practical Chroma entry point and a Wan default that is more appropriate for phones. The old low-memory cutoff did not account for the actual model bundle and could still start unsafe loads.

## Validation

- `:app:testDebugUnitTest` — 27 tests, 0 failures.
- Installed and tested on an S22 with the Q3 Wan bundle; the app reported the memory refusal without losing the worker or restarting the phone.