### PR TITLE
Add the mobile Chroma preset to the example app

### DIFF
--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
@@ -98,6 +98,7 @@ class ImageGenerationActivity : AppCompatActivity() {
             R.id.presetSd3Medium -> ImageModelPreset.SD3_MEDIUM
             R.id.presetMiniT2i -> ImageModelPreset.MINI_T2I
             R.id.presetMiniT2iLarge -> ImageModelPreset.MINI_T2I_LARGE
+            R.id.presetChromaMobile -> ImageModelPreset.CHROMA_MOBILE
             R.id.presetChromaRadiance -> ImageModelPreset.CHROMA_RADIANCE
             else -> ImageModelPreset.SD15
         }

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageModelPreset.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageModelPreset.kt
@@ -19,6 +19,7 @@ internal enum class ImageModelPreset(
     SD3_MEDIUM(512, 512, 28, 4.5f, false),
     MINI_T2I(512, 512, 100, 6.0f, false),
     MINI_T2I_LARGE(512, 512, 100, 6.0f, false),
+    CHROMA_MOBILE(512, 512, 20, 4.0f, false),
     CHROMA_RADIANCE(512, 512, 20, 4.0f, false);
 
     fun buildRequest(
@@ -71,6 +72,15 @@ internal enum class ImageModelPreset(
                 flashAttention = flashAttention,
             )
             MINI_T2I_LARGE -> MiniT2I.largeImageRequest(
+                prompt = prompt,
+                width = width,
+                height = height,
+                steps = steps,
+                cfgScale = cfg,
+                seed = seed,
+                flashAttention = flashAttention,
+            )
+            CHROMA_MOBILE -> ChromaRadiance.mobileImageRequest(
                 prompt = prompt,
                 width = width,
                 height = height,

--- a/app/src/main/res/layout/activity_image_generation.xml
+++ b/app/src/main/res/layout/activity_image_generation.xml
@@ -152,10 +152,16 @@
                 android:text="MiniT2I L/16 — FLAN-T5 Large (512×512, 100 steps, CFG 6)" />
 
             <RadioButton
+                android:id="@+id/presetChromaMobile"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Chroma1-HD Q3_K_S — mobile, sequential (~6.4GB download)" />
+
+            <RadioButton
                 android:id="@+id/presetChromaRadiance"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Chroma Radiance — split DiT + T5XXL (512×512, 20 steps, CFG 4)" />
+                android:text="Chroma Radiance Q4_K_S — high memory, sequential (~7.9GB download)" />
         </RadioGroup>
 
         <LinearLayout

--- a/app/src/test/java/com/example/llmedgeexample/demo/image/ImageModelPresetTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/demo/image/ImageModelPresetTest.kt
@@ -37,6 +37,10 @@ class ImageModelPresetTest {
         assertEquals(4.0f, ImageModelPreset.CHROMA_RADIANCE.defaultCfg)
         assertFalse(ImageModelPreset.CHROMA_RADIANCE.supportsLora)
 
+        assertEquals(20, ImageModelPreset.CHROMA_MOBILE.defaultSteps)
+        assertEquals(4.0f, ImageModelPreset.CHROMA_MOBILE.defaultCfg)
+        assertFalse(ImageModelPreset.CHROMA_MOBILE.supportsLora)
+
         ImageModelPreset.values().forEach { preset ->
             assertEquals(512, preset.defaultWidth)
             assertEquals(512, preset.defaultHeight)
@@ -171,5 +175,24 @@ class ImageModelPresetTest {
         assertEquals(true, request.sequential)
         assertEquals(20, request.steps)
         assertEquals(4.0f, request.cfgScale)
+    }
+
+    @Test
+    fun testBuildRequestChromaMobile() {
+        val request = ImageModelPreset.CHROMA_MOBILE.buildRequest(
+            prompt = "a small robot",
+            width = 512,
+            height = 512,
+            steps = 20,
+            cfg = 4.0f,
+            seed = 42L,
+            flashAttention = true,
+        )
+
+        assertEquals(io.aatricks.llmedge.image.ChromaRadiance.mobileDiffusionModel, request.model)
+        assertEquals(io.aatricks.llmedge.image.ChromaRadiance.t5xxl, request.t5xxl)
+        assertNull(request.vae)
+        assertTrue(request.splitDiffusionModel)
+        assertEquals(true, request.sequential)
     }
 }


### PR DESCRIPTION
## What changed

- Added a Chroma1-HD Q3_K_S mobile option to the image example.
- Kept Chroma Radiance Q4_K_S as a separate high-memory option.
- Updated the labels with the quantization and approximate download size.
- Added request-building tests for the mobile preset.

## Why

Radiance Q4_K_S is too large for the tested 16GB WP55. The example now points phone users to the smaller Q3 model without removing Radiance for devices that pass the SDK memory check.

## Checks

- `./gradlew :app:testDebugUnitTest`
- Debug APK assembled and its v2 signature verified
