### PR TITLE
Add negative prompt input to image and video generation

### DIFF
--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
@@ -133,6 +133,7 @@ class ImageGenerationActivity : AppCompatActivity() {
         views.progressBar.isIndeterminate = true
         views.generateButton.isEnabled = false
         val prompt = views.promptInput.text.toString().ifBlank { DEFAULT_PROMPT }
+        val negative = views.negativePromptInput.text.toString().trim()
         val preset = selectedPreset()
         val loraRequested = views.loraToggle.isChecked && preset.supportsLora
 
@@ -140,6 +141,7 @@ class ImageGenerationActivity : AppCompatActivity() {
         val baseRequest =
             preset.buildRequest(
                 prompt = prompt,
+                negative = negative,
                 width = width,
                 height = height,
                 steps = steps,

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationViews.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationViews.kt
@@ -12,6 +12,7 @@ import com.example.llmedgeexample.R
 
 internal data class ImageGenerationViews(
     val promptInput: EditText,
+    val negativePromptInput: EditText,
     val widthInput: EditText,
     val heightInput: EditText,
     val stepsInput: EditText,
@@ -32,6 +33,7 @@ internal data class ImageGenerationViews(
         fun bind(activity: Activity): ImageGenerationViews =
             ImageGenerationViews(
                 promptInput = activity.findViewById(R.id.videoPromptInput),
+                negativePromptInput = activity.findViewById(R.id.imageNegativePromptInput),
                 widthInput = activity.findViewById(R.id.imageWidthInput),
                 heightInput = activity.findViewById(R.id.imageHeightInput),
                 stepsInput = activity.findViewById(R.id.imageStepsInput),

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageModelPreset.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageModelPreset.kt
@@ -30,8 +30,9 @@ internal enum class ImageModelPreset(
         cfg: Float,
         seed: Long,
         flashAttention: Boolean,
+        negative: String = "",
     ): ImageGenerationRequest {
-        return when (this) {
+        val request = when (this) {
             SD15 -> ImageGenerationRequest(
                 prompt = prompt,
                 width = width,
@@ -99,5 +100,6 @@ internal enum class ImageModelPreset(
                 flashAttention = flashAttention,
             )
         }
+        return request.copy(negative = negative)
     }
 }

--- a/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationActivity.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationActivity.kt
@@ -358,6 +358,7 @@ class VideoGenerationActivity : AppCompatActivity() {
 
         return VideoGenerationConfig(
             prompt = views.promptInput.text.toString().ifBlank { DEFAULT_PROMPT },
+            negative = views.negativePromptInput.text.toString().trim(),
             width = width,
             height = height,
             frames = framesCount,

--- a/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationController.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationController.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.withContext
 
 data class VideoGenerationConfig(
     val prompt: String,
+    val negative: String = "",
     val width: Int,
     val height: Int,
     val frames: Int,
@@ -115,6 +116,7 @@ class VideoGenerationController(
                     val request =
                         VideoGenerationRequest(
                             prompt = config.prompt,
+                            negative = config.negative,
                             width = config.width,
                             height = config.height,
                             videoFrames = config.frames,

--- a/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationViews.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/video/VideoGenerationViews.kt
@@ -12,6 +12,7 @@ import com.example.llmedgeexample.R
 
 internal data class VideoGenerationViews(
     val promptInput: EditText,
+    val negativePromptInput: EditText,
     val widthInput: EditText,
     val heightInput: EditText,
     val framesInput: EditText,
@@ -49,6 +50,7 @@ internal data class VideoGenerationViews(
         fun bind(activity: Activity): VideoGenerationViews =
             VideoGenerationViews(
                 promptInput = activity.findViewById(R.id.videoPromptInput),
+                negativePromptInput = activity.findViewById(R.id.videoNegativePromptInput),
                 widthInput = activity.findViewById(R.id.videoWidthInput),
                 heightInput = activity.findViewById(R.id.videoHeightInput),
                 framesInput = activity.findViewById(R.id.videoFramesInput),

--- a/app/src/main/res/layout/activity_image_generation.xml
+++ b/app/src/main/res/layout/activity_image_generation.xml
@@ -28,6 +28,17 @@
             android:background="@android:drawable/edit_text"
             android:padding="12dp" />
 
+        <EditText
+            android:id="@+id/imageNegativePromptInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:hint="Negative prompt (optional)"
+            android:minLines="2"
+            android:gravity="top"
+            android:background="@android:drawable/edit_text"
+            android:padding="12dp" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_video_generation.xml
+++ b/app/src/main/res/layout/activity_video_generation.xml
@@ -35,6 +35,17 @@
             android:background="@android:drawable/edit_text"
             android:padding="12dp" />
 
+        <EditText
+            android:id="@+id/videoNegativePromptInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:hint="Negative prompt (optional)"
+            android:minLines="2"
+            android:gravity="top"
+            android:background="@android:drawable/edit_text"
+            android:padding="12dp" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/test/java/com/example/llmedgeexample/demo/image/ImageModelPresetTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/demo/image/ImageModelPresetTest.kt
@@ -191,8 +191,39 @@ class ImageModelPresetTest {
 
         assertEquals(io.aatricks.llmedge.image.ChromaRadiance.mobileDiffusionModel, request.model)
         assertEquals(io.aatricks.llmedge.image.ChromaRadiance.t5xxl, request.t5xxl)
-        assertNull(request.vae)
+        assertEquals(io.aatricks.llmedge.image.ChromaRadiance.fluxVae, request.vae)
         assertTrue(request.splitDiffusionModel)
         assertEquals(true, request.sequential)
+    }
+
+    @Test
+    fun testBuildRequestPassesNegativePrompt() {
+        ImageModelPreset.values().forEach { preset ->
+            val request = preset.buildRequest(
+                prompt = "a small robot",
+                negative = "blurry, low quality",
+                width = 512,
+                height = 512,
+                steps = preset.defaultSteps,
+                cfg = preset.defaultCfg,
+                seed = 42L,
+                flashAttention = true,
+            )
+            assertEquals("blurry, low quality", request.negative)
+        }
+    }
+
+    @Test
+    fun testBuildRequestDefaultsToEmptyNegativePrompt() {
+        val request = ImageModelPreset.SD15.buildRequest(
+            prompt = "a small robot",
+            width = 512,
+            height = 512,
+            steps = 20,
+            cfg = 7.0f,
+            seed = 42L,
+            flashAttention = true,
+        )
+        assertEquals("", request.negative)
     }
 }


### PR DESCRIPTION
Adds an optional negative prompt field under the prompt on both the image and video generation screens. The value goes through ImageModelPreset.buildRequest and VideoGenerationConfig into the SDK requests, which already carry a negative field, so a blank input keeps today's behavior.

Also updates the Chroma mobile preset test to expect the FLUX VAE now attached SDK-side (Aatricks/llmedge#56).

App unit suite passes (30 tests).