### PR TITLE
Probe GPU backends off the startup path

### DIFF
--- a/app/src/main/java/com/example/llmedgeexample/app/LLMEdgeExampleApp.kt
+++ b/app/src/main/java/com/example/llmedgeexample/app/LLMEdgeExampleApp.kt
@@ -2,6 +2,10 @@ package com.example.llmedgeexample.app
 
 import android.app.Application
 import com.example.llmedgeexample.common.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 /**
  * Application class for LLMEdge Example app.
@@ -31,18 +35,21 @@ class LLMEdgeExampleApp : Application() {
         
         logMemoryState("Application started")
         
-        val gpuStatus = detectGpuBackendStatus()
-        if (gpuStatus.openClAvailable || gpuStatus.vulkanAvailable) {
-            FileLogger.i(TAG, "GPU backends available: ${gpuStatus.summary()}")
-            gpuStatus.vulkanInfo?.let { vulkanInfo ->
-                FileLogger.i(
-                    TAG,
-                    "Vulkan available: ${vulkanInfo.deviceCount} device(s), " +
-                        "${vulkanInfo.freeMemoryMB}MB free / ${vulkanInfo.totalMemoryMB}MB total",
-                )
+        val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        appScope.launch {
+            val gpuStatus = probeGpuBackendStatus(this@LLMEdgeExampleApp)
+            if (gpuStatus.openClAvailable || gpuStatus.vulkanAvailable) {
+                FileLogger.i(TAG, "GPU backends available: ${gpuStatus.summary()}")
+                gpuStatus.vulkanInfo?.let { vulkanInfo ->
+                    FileLogger.i(
+                        TAG,
+                        "Vulkan available: ${vulkanInfo.deviceCount} device(s), " +
+                            "${vulkanInfo.freeMemoryMB}MB free / ${vulkanInfo.totalMemoryMB}MB total",
+                    )
+                }
+            } else {
+                FileLogger.w(TAG, "GPU backends unavailable - CPU fallback only")
             }
-        } else {
-            FileLogger.w(TAG, "GPU backends unavailable - CPU fallback only")
         }
     }
 
@@ -76,7 +83,7 @@ class LLMEdgeExampleApp : Application() {
      */
     fun logMemoryState(phase: String) {
         val snapshot = demoMemorySnapshot()
-        logDemoMemoryState(TAG, phase, includeGpu = true) { FileLogger.i(TAG, it) }
+        logDemoMemoryState(TAG, phase, includeGpu = false) { FileLogger.i(TAG, it) }
         FileLogger.i(TAG, "  Heap free: ${snapshot.heapMaxMb - snapshot.heapUsedMb}MB")
     }
     

--- a/app/src/main/java/com/example/llmedgeexample/app/LLMEdgeExampleApp.kt
+++ b/app/src/main/java/com/example/llmedgeexample/app/LLMEdgeExampleApp.kt
@@ -34,7 +34,11 @@ class LLMEdgeExampleApp : Application() {
         FileLogger.i(TAG, "Log file: ${FileLogger.getCurrentLogFile()}")
         
         logMemoryState("Application started")
-        
+
+        // onCreate also runs in the :llmedge_sd worker process; only the main
+        // process should kick off the GPU probe (which itself spawns that worker).
+        if (getProcessName() != packageName) return
+
         val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         appScope.launch {
             val gpuStatus = probeGpuBackendStatus(this@LLMEdgeExampleApp)

--- a/app/src/main/java/com/example/llmedgeexample/common/DemoDiagnostics.kt
+++ b/app/src/main/java/com/example/llmedgeexample/common/DemoDiagnostics.kt
@@ -46,7 +46,7 @@ fun Context.logDemoMemoryState(
     logger: (String) -> Unit = { message -> Log.i(tag, message) },
 ) {
     val snapshot = demoMemorySnapshot()
-    val gpuStatus = if (includeGpu) detectGpuBackendStatus() else null
+    val gpuStatus = if (includeGpu) detectGpuBackendStatus(this) else null
     logger("=== Memory: $phase ===")
     logger("  Heap: ${snapshot.heapUsedMb}MB / ${snapshot.heapMaxMb}MB max")
     logger("  System: ${snapshot.systemAvailableMb}MB / ${snapshot.systemTotalMb}MB total")
@@ -62,7 +62,7 @@ fun Context.logDemoMemoryState(
 
 fun Context.buildDemoMemorySummary(cpuOnlyOverride: Boolean): String {
     val snapshot = demoMemorySnapshot()
-    val gpuStatus = detectGpuBackendStatus()
+    val gpuStatus = detectGpuBackendStatus(this)
     return buildString {
         appendLine(
             "System: ${snapshot.systemUsedMb}MB / ${snapshot.systemTotalMb}MB (${snapshot.systemAvailableMb}MB free)"

--- a/app/src/main/java/com/example/llmedgeexample/common/EdgeSupport.kt
+++ b/app/src/main/java/com/example/llmedgeexample/common/EdgeSupport.kt
@@ -78,12 +78,26 @@ data class GpuBackendStatus(
         get() = image.vulkanDeviceInfo
 }
 
-fun detectGpuBackendStatus(): GpuBackendStatus =
+suspend fun probeGpuBackendStatus(context: Context): GpuBackendStatus {
+    if (isCpuOnlyForced(context)) {
+        val allFalse = ComputeBackendAvailability(false, false, null)
+        return GpuBackendStatus(allFalse, allFalse, allFalse, allFalse)
+    }
+    LLMEdge.probeImageBackendAvailability(context)
+    return GpuBackendStatus(
+        text = LLMEdge.getTextBackendAvailability(context),
+        speech = LLMEdge.getSpeechBackendAvailability(context),
+        image = LLMEdge.getImageBackendAvailability(context),
+        vision = LLMEdge.getVisionBackendAvailability(context),
+    )
+}
+
+fun detectGpuBackendStatus(context: Context): GpuBackendStatus =
     GpuBackendStatus(
-        text = LLMEdge.getTextBackendAvailability(),
-        speech = LLMEdge.getSpeechBackendAvailability(),
-        image = LLMEdge.getImageBackendAvailability(),
-        vision = LLMEdge.getVisionBackendAvailability(),
+        text = LLMEdge.getTextBackendAvailability(context),
+        speech = LLMEdge.getSpeechBackendAvailability(context),
+        image = LLMEdge.getImageBackendAvailability(context),
+        vision = LLMEdge.getVisionBackendAvailability(context),
     )
 
 fun GpuBackendStatus.summary(): String {


### PR DESCRIPTION
Fixes #29.

`Application.onCreate` ran the full GPU backend probe synchronously on the main thread, making live Vulkan driver calls in-process before the first frame; on devices with fragile drivers (Tab A9+ / Adreno 619) the driver aborts and kills the app at the logo screen, before any log can be captured.

- Startup logging no longer includes the GPU section; the probe runs on a background scope through the SDK's new isolated-worker API (Aatricks/llmedge#59), so a driver crash is contained in the worker process and the device falls back to CPU.
- `Force CPU only` is now honored by the probe itself, not just `bindEdge`.
- Diagnostics read cached probe results instead of re-probing.

Tests: `:app:assembleDebug` + 40 unit tests green. Needs Aatricks/llmedge#59 (new SDK API) and an updated AAR before merge; a debug APK for the reporter to verify on the Tab A9+ should come from CI after that.