### PR TITLE
Force staged Hyper-SD3 generation

### DIFF
--- a/app/src/androidTest/java/com/example/llmedgeexample/demo/video/Issue31WanDeviceE2ETest.kt
+++ b/app/src/androidTest/java/com/example/llmedgeexample/demo/video/Issue31WanDeviceE2ETest.kt
@@ -192,12 +192,13 @@ class Issue31WanDeviceE2ETest {
                                 seed = 42L,
                                 flashAttention = true,
                                 easyCacheEnabled = false,
-                            ).copy(forceSequentialLoad = true),
+                            ),
                         loraRequested = false,
                         hyperSd3Requested = true,
                     )
                 }
 
+            assertEquals(true, prepared.request.sequential)
             val bitmap =
                 withTimeout(90 * 60_000L) {
                     edge.image.generate(prepared.request)

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationRequestPreparer.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationRequestPreparer.kt
@@ -70,6 +70,7 @@ internal class ImageGenerationRequestPreparer(
                                 ),
                             steps = if (isHyperSd3) 4 else baseRequest.steps,
                             cfgScale = if (isHyperSd3) 3.0f else baseRequest.cfgScale,
+                            sequential = if (isHyperSd3) true else baseRequest.sequential,
                             loraModelDir = loraDirectory,
                             loraApplyMode = LoraApplyMode.AUTO,
                         ),

--- a/app/src/test/java/com/example/llmedgeexample/demo/image/ImageGenerationRequestPreparerTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/demo/image/ImageGenerationRequestPreparerTest.kt
@@ -142,6 +142,7 @@ class ImageGenerationRequestPreparerTest {
         assertEquals(4, prepared.request.steps)
         assertEquals(3.0f, prepared.request.cfgScale)
         assertEquals(loraDirectory.absolutePath, prepared.request.loraModelDir)
+        assertEquals(true, prepared.request.sequential)
     }
 
     @Test(expected = CancellationException::class)


### PR DESCRIPTION
Hyper-SD3 now always uses staged image generation. This avoids the all-at-once SD3 load selected on devices that report enough free RAM, where adding the 450 MB LoRA could crash the worker.

The device E2E now submits the same request as the app.

Tests:
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:compileDebugAndroidTestKotlin`
- `./gradlew :app:assembleRelease`