### PR TITLE
Reject all-in-one GGUF imports for diffusion-only presets

### DIFF
--- a/app/src/main/java/com/example/llmedgeexample/common/ImportedModelSupport.kt
+++ b/app/src/main/java/com/example/llmedgeexample/common/ImportedModelSupport.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.OpenableColumns
+import io.aatricks.llmedge.model.GgufComponent
+import io.aatricks.llmedge.model.GgufFileSummary
 import io.aatricks.llmedge.model.ModelFileValidator
 import java.io.File
 import java.io.InputStream
@@ -15,7 +17,17 @@ import java.security.MessageDigest
 internal data class ImportedModel(
     val file: File,
     val displayName: String,
-)
+    /** Header facts, when parseable — logged so a field bug report names the actual file. */
+    val summary: GgufFileSummary? = null,
+) {
+    /** A one-line description of what the file actually contains, for the app log. */
+    fun describe(): String =
+        summary?.let {
+            "arch=${it.architecture ?: "unknown"}, tensors=${it.tensorCount}, " +
+                "components=${it.components.sorted().joinToString("+").ifEmpty { "unrecognised" }}, " +
+                "bytes=${file.length()}"
+        } ?: "unparseable GGUF header, bytes=${file.length()}"
+}
 
 internal object ImportedModelSupport {
     fun createPickerIntent(title: String): Intent =
@@ -31,6 +43,7 @@ internal object ImportedModelSupport {
         context: Context,
         uri: Uri,
         internalNamePrefix: String = "",
+        requireDiffusionOnly: Boolean = false,
     ): ImportedModel {
         val displayName =
             context.getOpenableDisplayName(
@@ -56,6 +69,7 @@ internal object ImportedModelSupport {
                 input = it,
                 internalNamePrefix = internalNamePrefix,
                 expectedSizeBytes = expectedSizeBytes,
+                requireDiffusionOnly = requireDiffusionOnly,
             )
         }
     }
@@ -66,6 +80,7 @@ internal object ImportedModelSupport {
         input: InputStream,
         internalNamePrefix: String = "",
         expectedSizeBytes: Long? = null,
+        requireDiffusionOnly: Boolean = false,
         availableBytesProvider: (File) -> Long = { directory ->
             android.os.StatFs(directory.absolutePath).availableBytes
         },
@@ -93,6 +108,7 @@ internal object ImportedModelSupport {
         val slotPrefix = safePrefix.ifBlank { "model-" }
         val partialFile = File(targetDirectory, "${slotPrefix}import.partial")
         var targetFile: File? = null
+        var summary: GgufFileSummary? = null
         try {
             partialFile.delete()
             val digest = MessageDigest.getInstance("SHA-256")
@@ -106,6 +122,10 @@ internal object ImportedModelSupport {
                 }
             }
             ModelFileValidator.requireGgufFile(partialFile.absolutePath, "Imported model")
+            summary = GgufFileSummary.read(partialFile)
+            if (requireDiffusionOnly) {
+                requireDiffusionOnlyCheckpoint(summary, safeDisplayName)
+            }
             val contentHash = digest.digest().joinToString("") { "%02x".format(it) }
             val destination = File(targetDirectory, "$slotPrefix$contentHash.gguf")
             targetFile = destination
@@ -135,6 +155,38 @@ internal object ImportedModelSupport {
         return ImportedModel(
             file = requireNotNull(targetFile),
             displayName = safeDisplayName,
+            summary = summary,
+        )
+    }
+
+    /**
+     * Rejects an all-in-one checkpoint for a preset that loads the text encoders and VAE
+     * separately. Such a file goes into `diffusion_model_path`, so its baked-in encoders and the
+     * preset's downloaded ones are both loaded — a misconfiguration that surfaces later as a
+     * generation-time crash rather than a load error, which makes it near-impossible to diagnose
+     * from the app log alone.
+     *
+     * Unreadable headers pass: this is here to explain a known mistake, not to gate imports.
+     */
+    private fun requireDiffusionOnlyCheckpoint(
+        summary: GgufFileSummary?,
+        displayName: String,
+    ) {
+        if (summary == null || !summary.isAllInOne) return
+        val bundled =
+            summary.components
+                .filter { it != GgufComponent.DIFFUSION }
+                .joinToString(" and ") {
+                    when (it) {
+                        GgufComponent.TEXT_ENCODER -> "text encoders"
+                        GgufComponent.VAE -> "a VAE"
+                        GgufComponent.DIFFUSION -> "a denoiser"
+                    }
+                }
+        throw IllegalArgumentException(
+            "$displayName is an all-in-one checkpoint (it bundles $bundled). This preset " +
+                "downloads those separately and needs a diffusion-model-only file. Pick a " +
+                "DiT-only GGUF, or switch to the SD 1.5 preset for all-in-one checkpoints.",
         )
     }
 

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationActivity.kt
@@ -212,12 +212,17 @@ class ImageGenerationActivity : AppCompatActivity() {
                             context = this@ImageGenerationActivity,
                             uri = uri,
                             internalNamePrefix = internalNamePrefix,
+                            requireDiffusionOnly = selectedPreset().expectsDiffusionOnlyGguf,
                         )
                     }
                 selectedModelOverride = ModelSpec.localFile(imported.file)
                 views.modelLabel.text = imported.displayName
                 views.clearModelButton.visibility = View.VISIBLE
-                FileLogger.i(TAG, "Imported compatible image model: ${imported.file.absolutePath}")
+                FileLogger.i(
+                    TAG,
+                    "Imported image model for ${selectedPreset()}: ${imported.file.absolutePath} " +
+                        "(${imported.describe()})",
+                )
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (t: Throwable) {

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationController.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageGenerationController.kt
@@ -127,6 +127,9 @@ internal class ImageGenerationController(
 
         generationJob =
             scope.launch(ioDispatcher) {
+                // Step progress is otherwise UI-only, which leaves a shared app log unable to say
+                // whether a crash happened before the first step or during the last one.
+                var stepsReached = "none"
                 try {
                     withContext(mainDispatcher) {
                         callbacks.onProgress(0, "Preparing...")
@@ -142,6 +145,7 @@ internal class ImageGenerationController(
                     runtime.generateStream(config.request).collect { event ->
                         when (event) {
                             is GenerationStreamEvent.Progress -> {
+                                stepsReached = "${event.update.current}/${event.update.total}"
                                 val snap = estimator.onStep(event.update.current, event.update.total)
                                 withContext(mainDispatcher) {
                                     callbacks.onProgress(snap.percent, snap.label)
@@ -180,7 +184,8 @@ internal class ImageGenerationController(
                     cancellationReason = ImageGenerationCancellationReason.ERROR
                     updatePhase("out of memory")
                     logError(
-                        "Image request failed with OOM: requestId=$requestId, phase=$currentPhaseText",
+                        "Image request failed with OOM: requestId=$requestId, phase=$currentPhaseText, " +
+                            "stepsReached=$stepsReached",
                         oom,
                     )
                     withContext(NonCancellable + mainDispatcher) {
@@ -190,7 +195,8 @@ internal class ImageGenerationController(
                     cancellationReason = ImageGenerationCancellationReason.ERROR
                     updatePhase("failed")
                     logError(
-                        "Image request failed: requestId=$requestId, phase=$currentPhaseText, message=${t.message}",
+                        "Image request failed: requestId=$requestId, phase=$currentPhaseText, " +
+                            "stepsReached=$stepsReached, message=${t.message}",
                         t,
                     )
                     withContext(NonCancellable + mainDispatcher) {

--- a/app/src/main/java/com/example/llmedgeexample/demo/image/ImageModelPreset.kt
+++ b/app/src/main/java/com/example/llmedgeexample/demo/image/ImageModelPreset.kt
@@ -14,14 +14,20 @@ internal enum class ImageModelPreset(
     val defaultSteps: Int,
     val defaultCfg: Float,
     val supportsLora: Boolean,
+    /**
+     * True when this preset routes its model to `diffusion_model_path` and loads the text
+     * encoders and VAE separately, so an imported all-in-one checkpoint would be loaded twice
+     * over — once as the denoiser, once as the downloaded components.
+     */
+    val expectsDiffusionOnlyGguf: Boolean,
 ) {
-    SD15(512, 512, 20, 7.0f, true),
-    FLUX2_KLEIN_BONSAI(512, 512, 4, 1.0f, false),
-    SD3_MEDIUM(512, 512, 28, 4.5f, false),
-    MINI_T2I(512, 512, 100, 6.0f, false),
-    MINI_T2I_LARGE(512, 512, 100, 6.0f, false),
-    CHROMA_MOBILE(512, 512, 20, 4.0f, false),
-    CHROMA_RADIANCE(512, 512, 20, 4.0f, false);
+    SD15(512, 512, 20, 7.0f, true, expectsDiffusionOnlyGguf = false),
+    FLUX2_KLEIN_BONSAI(512, 512, 4, 1.0f, false, expectsDiffusionOnlyGguf = true),
+    SD3_MEDIUM(512, 512, 28, 4.5f, false, expectsDiffusionOnlyGguf = true),
+    MINI_T2I(512, 512, 100, 6.0f, false, expectsDiffusionOnlyGguf = true),
+    MINI_T2I_LARGE(512, 512, 100, 6.0f, false, expectsDiffusionOnlyGguf = true),
+    CHROMA_MOBILE(512, 512, 20, 4.0f, false, expectsDiffusionOnlyGguf = true),
+    CHROMA_RADIANCE(512, 512, 20, 4.0f, false, expectsDiffusionOnlyGguf = true);
 
     fun buildRequest(
         prompt: String,

--- a/app/src/test/java/com/example/llmedgeexample/common/ImportedModelSupportTest.kt
+++ b/app/src/test/java/com/example/llmedgeexample/common/ImportedModelSupportTest.kt
@@ -135,6 +135,123 @@ class ImportedModelSupportTest {
         assertFalse(input.wasRead)
     }
 
+    /**
+     * llmedge-examples#37: importing an all-in-one SD3 checkpoint into a preset that routes it to
+     * `diffusion_model_path` silently double-loads the encoders, and only surfaces much later as a
+     * generation-time worker crash.
+     */
+    @Test
+    fun `all-in-one checkpoint is rejected for a diffusion-only preset`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        try {
+            ImportedModelSupport.copyToAppStorage(
+                context = context,
+                displayName = "sd3-medium-Q4_0.gguf",
+                input = ByteArrayInputStream(
+                    ggufFile(
+                        "sd3",
+                        listOf(
+                            "model.diffusion_model.joint_blocks.0.weight",
+                            "text_encoders.clip_l.transformer.weight",
+                            "first_stage_model.decoder.conv_in.weight",
+                        ),
+                    ),
+                ),
+                internalNamePrefix = "sd3-${System.nanoTime()}-",
+                requireDiffusionOnly = true,
+            )
+            fail("Expected an all-in-one checkpoint to be rejected")
+        } catch (expected: IllegalArgumentException) {
+            val message = expected.message.orEmpty()
+            assertTrue(message, message.contains("all-in-one"))
+            assertTrue(message, message.contains("text encoders"))
+        }
+    }
+
+    @Test
+    fun `all-in-one checkpoint is accepted when the preset expects one`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val imported =
+            ImportedModelSupport.copyToAppStorage(
+                context = context,
+                displayName = "sd15-all-in-one.gguf",
+                input = ByteArrayInputStream(
+                    ggufFile("sd1", listOf("model.diffusion_model.a.weight", "first_stage_model.b.weight")),
+                ),
+                internalNamePrefix = "stable-diffusion-${System.nanoTime()}-",
+                requireDiffusionOnly = false,
+            )
+
+        assertTrue(imported.file.isFile)
+        assertTrue(imported.describe().contains("arch=sd1"))
+    }
+
+    @Test
+    fun `diffusion-only checkpoint passes the diffusion-only check`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val imported =
+            ImportedModelSupport.copyToAppStorage(
+                context = context,
+                displayName = "sd3_medium-Q4_0.gguf",
+                input = ByteArrayInputStream(
+                    ggufFile("sd3", listOf("model.diffusion_model.joint_blocks.0.weight")),
+                ),
+                internalNamePrefix = "sd3-${System.nanoTime()}-",
+                requireDiffusionOnly = true,
+            )
+
+        assertTrue(imported.file.isFile)
+        assertTrue(imported.describe().contains("DIFFUSION"))
+    }
+
+    @Test
+    fun `an unparseable header does not block an otherwise valid import`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val imported =
+            ImportedModelSupport.copyToAppStorage(
+                context = context,
+                displayName = "opaque.gguf",
+                input = ByteArrayInputStream(ggufBytes(9)),
+                internalNamePrefix = "opaque-${System.nanoTime()}-",
+                requireDiffusionOnly = true,
+            )
+
+        assertTrue(imported.file.isFile)
+        assertTrue(imported.describe().contains("unparseable"))
+    }
+
+    /** Minimal GGUF v3 header: magic, counts, one string metadata entry, then tensor infos. */
+    private fun ggufFile(architecture: String, tensorNames: List<String>): ByteArray {
+        val out = java.io.ByteArrayOutputStream()
+        fun u32(value: Long) = repeat(4) { out.write(((value shr (it * 8)) and 0xFF).toInt()) }
+        fun u64(value: Long) = repeat(8) { out.write(((value shr (it * 8)) and 0xFF).toInt()) }
+        fun str(value: String) {
+            val bytes = value.toByteArray(Charsets.UTF_8)
+            u64(bytes.size.toLong())
+            out.write(bytes)
+        }
+
+        out.write("GGUF".toByteArray(Charsets.US_ASCII))
+        u32(3)
+        u64(tensorNames.size.toLong())
+        u64(1)
+        str("general.architecture")
+        u32(8)
+        str(architecture)
+        tensorNames.forEach { name ->
+            str(name)
+            u32(1)
+            u64(16)
+            u32(0)
+            u64(0)
+        }
+        return out.toByteArray()
+    }
+
     private fun ggufBytes(marker: Int): ByteArray =
         byteArrayOf(
             'G'.code.toByte(),


### PR DESCRIPTION
Follow-up to #37, where a custom SD3 GGUF import crashed the diffusion worker 3m26s into `phase=GENERATING`.

## Why

The SD3 preset sets `splitDiffusionModel=true`, so an imported model is routed to `diffusion_model_path` while CLIP-L/CLIP-G/T5/VAE download separately. Import only validated the GGUF magic bytes, so an all-in-one checkpoint (e.g. `second-state/sd3-medium-Q4_0.gguf`) was accepted into the denoiser slot and its baked-in encoders were loaded on top of the downloaded ones. That misconfiguration surfaces later as a generation-time worker crash rather than a load error, which makes it near-impossible to diagnose from the app log.

The `Imported compatible image model` log line reinforced this — "compatible" only ever meant the first four bytes read `GGUF`.

## What changed

- Import parses the GGUF header (`GgufFileSummary`, added on the SDK side) and rejects an all-in-one checkpoint for presets that load encoders separately, naming the actual problem. An unparseable header always passes: this exists to explain a known mistake, not to gate imports.
- `ImageModelPreset.expectsDiffusionOnlyGguf` records which presets route to `diffusion_model_path`. SD 1.5 is the only one that legitimately takes an all-in-one file.
- The import log line now reports architecture, tensor count, detected components and byte size, so a bug report names the actual file.
- Failure logs record `stepsReached`, which distinguishes a crash before denoising started from one during it. Step progress was previously UI-only.

## Verification

`:app:testDebugUnitTest` green. `ImportedModelSupportTest` 9/9, with 4 new cases: all-in-one rejected for a diffusion-only preset, all-in-one accepted for SD 1.5, diffusion-only accepted, and an unparseable header still importing.