### PR TITLE
Cover the non-square Hyper-SD3 path on device

### DIFF
--- a/app/src/androidTest/java/com/example/llmedgeexample/demo/video/Issue31WanDeviceE2ETest.kt
+++ b/app/src/androidTest/java/com/example/llmedgeexample/demo/video/Issue31WanDeviceE2ETest.kt
@@ -223,4 +223,69 @@ class Issue31WanDeviceE2ETest {
             scope.cancel()
         }
     }
+
+    /**
+     * The configuration from llmedge-examples#37: the Hyper-SD3 sequential path at a non-square,
+     * non-default resolution. Square 256x256 is already covered above; aspect ratio is the axis
+     * that has previously broken diffusion runtimes here (see the MiniT2I positional-embedding
+     * fix), and 576x320 is what the field report actually ran.
+     */
+    @Test
+    fun hyperSd3LoraGeneratesNonSquareImageOnDevice() = runBlocking {
+        assumeTrue(
+            "Enable with -e llmedge.issue37NonSquareE2E 1",
+            InstrumentationRegistry.getArguments()
+                .getString("llmedge.issue37NonSquareE2E") == "1",
+        )
+        assumeTrue("Requires arm64 device", Build.SUPPORTED_ABIS.any { it.contains("arm64") })
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val edge = LLMEdge.create(context, scope)
+        try {
+            val prepared =
+                withTimeout(30 * 60_000L) {
+                    ImageGenerationRequestPreparer().prepare(
+                        edge = edge,
+                        baseRequest =
+                            ImageModelPreset.SD3_MEDIUM.buildRequest(
+                                prompt = "a red fox in snow, detailed",
+                                width = 576,
+                                height = 320,
+                                steps = 28,
+                                cfg = 4.5f,
+                                seed = 42L,
+                                flashAttention = false,
+                                easyCacheEnabled = false,
+                            ),
+                        loraRequested = false,
+                        hyperSd3Requested = true,
+                    )
+                }
+            assertEquals(true, prepared.request.sequential)
+            assertEquals(4, prepared.request.steps)
+
+            val bitmap =
+                withTimeout(90 * 60_000L) {
+                    edge.image.generate(prepared.request)
+                }
+
+            assertEquals(576, bitmap.width)
+            assertEquals(320, bitmap.height)
+            val pixels = IntArray(bitmap.width * bitmap.height)
+            bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+            assertTrue("image is fully transparent or black", pixels.any { (it ushr 24) != 0 && (it and 0x00FFFFFF) != 0 })
+            assertTrue("image is a single flat colour", pixels.toSet().size > 1)
+
+            val outputDirectory = requireNotNull(context.getExternalFilesDir("issue31"))
+            val outputFile = File(outputDirectory, "hyper-sd3-4step-576x320-seed42.png")
+            FileOutputStream(outputFile).use { output ->
+                assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+            }
+            assertTrue(outputFile.length() > 0L)
+        } finally {
+            edge.close()
+            scope.cancel()
+        }
+    }
 }


### PR DESCRIPTION
Adds the configuration from #37 to the device E2E suite: the Hyper-SD3 sequential path at a non-square, non-default resolution. The existing `hyperSd3LoraGeneratesImageOnDevice` only covers square 256x256, and aspect ratio is the axis that has previously broken diffusion runtimes here — see the MiniT2I positional-embedding fix.

Opt-in via `-e llmedge.issue37NonSquareE2E 1`, like its neighbours.

## Result on a Galaxy S22 (Android 16, arm64, 7.4 GB)

Both generation tests pass — 5 tests, 0 failures, 2 skipped on unset flags. 576x320 took 2816 s including the first-run model download; 256x256 took 1081 s with the models cached. Both images were pulled and inspected rather than trusted to the assertions, which only require a non-black pixel and more than one distinct colour: both are coherent renders of the prompt, and the 576x320 output is clean with no aspect distortion.

Observed pass sequence, which confirms the split conditioning behaves as designed:

```
CPU    clip_l.safetensors      sequential=true
VULKAN t5-v1_1-xxl-encoder     sequential=true
VULKAN sd3_medium-Q4_0.gguf    sequential=true
```

Only the CLIP pass is GPU-forbidden (`allowGpu = false` in `ImageRuntimeRequestPlanner`); the T5 spec gets `allowGpu = config.image.useVulkan`. Worth recording, because it narrows what `backend=CPU` means in a crash report: on a Vulkan-capable device, only the first conditioning pass reports CPU.

## What this says about #37

The reporter's settings do not reproduce his crash on stock SD3 weights. Sequential CLIP -> T5 -> DiT, the 4-step LoRA, and 576x320 all complete cleanly, and `combineSD3Condition` — which does dimension-sensitive array work between the T5 and DiT passes, and was a candidate for the throwable that escaped his worker — survives the non-square case.

That leaves his imported checkpoint as the remaining difference, consistent with the all-in-one hypothesis addressed by the import check.

## Note for anyone running this

`connectedAndroidTest` uninstalls the app afterwards, taking ~5.5 GB of downloaded models with it. Pass `-Pandroid.injected.androidTest.leaveApksInstalledAfterRun=true` unless you want to download them again. Separately, SD3 sequential needs roughly 2.5 GB of headroom and `ImageExecutionPlanner` refuses below it, which a normally-loaded 8 GB device can fail: the first attempt here died on `InsufficientMemoryException: requires approximately 2479MB with 2311MB safely available` until background processes were killed.